### PR TITLE
Fixes "Initializing firebase Auth without async Storage" Warning

### DIFF
--- a/project/serviceFiles/authService.ts
+++ b/project/serviceFiles/authService.ts
@@ -1,4 +1,7 @@
-import { getAuth } from "firebase/auth";
+import { getAuth, initializeAuth, getReactNativePersistence } from "firebase/auth";
 import { app } from "./firebaseConfig";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
-export const auth = getAuth(app);
+export const auth = initializeAuth(app, {
+   persistence: getReactNativePersistence(AsyncStorage),
+});

--- a/project/serviceFiles/authService.ts
+++ b/project/serviceFiles/authService.ts
@@ -1,4 +1,4 @@
-import { getAuth, initializeAuth, getReactNativePersistence } from "firebase/auth";
+import { initializeAuth, getReactNativePersistence } from "firebase/auth";
 import { app } from "./firebaseConfig";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 


### PR DESCRIPTION
There is always an error that pops up saying that firebase auth was not initialized with async storage. I fixed this. Also I am now getting a weird error saying that User does not exist, but somehow I can view my correct profile information, but it is an error inherited from main.